### PR TITLE
Support for multiple transport zones in get_scope

### DIFF
--- a/pynsxv/library/libutils.py
+++ b/pynsxv/library/libutils.py
@@ -94,9 +94,7 @@ def get_scope(client_session, transport_zone_name):
     """
     try:
         vdn_scopes = client_session.read('vdnScopes', 'read')['body']
-        print("vdn_scopes:  "+str(vdn_scopes))
         vdn_scope_list = client_session.normalize_list_return(vdn_scopes['vdnScopes'])
-        print("vdn_scope_list:  "+str(vdn_scope_list))
         # vdn_scope = [scope for scope in vdn_scope_list[0]['vdnScope']
         #              if scope['name'] == transport_zone_name][0]
         vdn_scope = []

--- a/pynsxv/library/libutils.py
+++ b/pynsxv/library/libutils.py
@@ -100,17 +100,16 @@ def get_scope(client_session, transport_zone_name):
         # vdn_scope = [scope for scope in vdn_scope_list[0]['vdnScope']
         #              if scope['name'] == transport_zone_name][0]
         vdn_scope = []
-        print("Iterating over vdn_scope_list...")
         for scope in vdn_scope_list:
-            print("scope['vdnScope']:  " + str(scope['vdnScope']))
-            for vdnScope in scope['vdnScope']:
-                print('vdnScope:  ' + str(vdnScope))
+            # It's possible scope['vdnScope'] is a single scope object or a list
+            # of scope objects if multiple transport zones exist.  Normalize to
+            # a list for finding the right scope in either scenario.
+            vdnScopes = scope['vdnScope'] if instanceof(scope['vdnScope'], list) else [scope['vdnScope']]
+
+            for vdnScope in vdnScopes:
                 if vdnScope['name'] == transport_zone_name:
-                    print("scope with TZ name:  " + str(scope))
                     vdn_scope.append(vdnScope)
         vdn_scope = vdn_scope[0]
-        # vdn_scope = [scope['vdnScope'] for scope in vdn_scope_list
-        #               if scope['vdnScope']['name'] == transport_zone_name][0]
     except KeyError:
         return None, None
 

--- a/pynsxv/library/libutils.py
+++ b/pynsxv/library/libutils.py
@@ -94,9 +94,15 @@ def get_scope(client_session, transport_zone_name):
     """
     try:
         vdn_scopes = client_session.read('vdnScopes', 'read')['body']
+        print("vdn_scopes:  "+str(vdn_scopes))
         vdn_scope_list = client_session.normalize_list_return(vdn_scopes['vdnScopes'])
+        print("vdn_scope_list:  "+str(vdn_scope_list))
         # vdn_scope = [scope for scope in vdn_scope_list[0]['vdnScope']
         #              if scope['name'] == transport_zone_name][0]
+        vdn_scope = None
+        for scope in vdn_scope_list:
+            if scope['vdnScope']['name'] == transport_zone_name:
+                print("scope with TZ name:  " + str(scope))
         vdn_scope = [scope['vdnScope'] for scope in vdn_scope_list
                       if scope['vdnScope']['name'] == transport_zone_name][0]
     except KeyError:

--- a/pynsxv/library/libutils.py
+++ b/pynsxv/library/libutils.py
@@ -100,7 +100,9 @@ def get_scope(client_session, transport_zone_name):
         # vdn_scope = [scope for scope in vdn_scope_list[0]['vdnScope']
         #              if scope['name'] == transport_zone_name][0]
         vdn_scope = None
+        print("Iterating over vdn_scope_list...")
         for scope in vdn_scope_list:
+            print("scope['vdnScope']:  " + str(scope['vdnScope']))
             if scope['vdnScope']['name'] == transport_zone_name:
                 print("scope with TZ name:  " + str(scope))
         vdn_scope = [scope['vdnScope'] for scope in vdn_scope_list

--- a/pynsxv/library/libutils.py
+++ b/pynsxv/library/libutils.py
@@ -99,14 +99,18 @@ def get_scope(client_session, transport_zone_name):
         print("vdn_scope_list:  "+str(vdn_scope_list))
         # vdn_scope = [scope for scope in vdn_scope_list[0]['vdnScope']
         #              if scope['name'] == transport_zone_name][0]
-        vdn_scope = None
+        vdn_scope = []
         print("Iterating over vdn_scope_list...")
         for scope in vdn_scope_list:
             print("scope['vdnScope']:  " + str(scope['vdnScope']))
-            if scope['vdnScope']['name'] == transport_zone_name:
-                print("scope with TZ name:  " + str(scope))
-        vdn_scope = [scope['vdnScope'] for scope in vdn_scope_list
-                      if scope['vdnScope']['name'] == transport_zone_name][0]
+            for vdnScope in scope['vdnScope']:
+                print('vdnScope:  ' + str(vdnScope))
+                if vdnScope['name'] == transport_zone_name:
+                    print("scope with TZ name:  " + str(scope))
+                    vdn_scope.append(vdnScope)
+        vdn_scope = vdn_scope[0]
+        # vdn_scope = [scope['vdnScope'] for scope in vdn_scope_list
+        #               if scope['vdnScope']['name'] == transport_zone_name][0]
     except KeyError:
         return None, None
 


### PR DESCRIPTION
In a customer environment where they had already defined multiple transport zones for various uses of their cluster, they were seeing the `get_scope` method throwing an exception when trying to create their logical switch:

```
line 101:  TypeError: list indices must be integers, not str
```

Debugging into the `get_scope` method throwing the error, we found their environment returns multiple scope objects in a list at `scope['vdnScope']` making the immediate call to the `name` property fail.  This replaces the existing list comprehension to handle both single object vdnScope and lists with multiple vdnScopes.